### PR TITLE
Migrate to windows_virtual_machine.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -77,25 +77,25 @@ resource azurerm_network_interface_security_group_association nic-nsg {
   network_security_group_id = azurerm_network_security_group.NSG.id
 }
 
-resource azurerm_virtual_machine VM {
+resource azurerm_windows_virtual_machine VM {
   name                             = var.name
   depends_on                       = [var.vm_depends_on]
   location                         = var.location
   resource_group_name              = var.resource_group_name
-  vm_size                          = var.vm_size
+  size                             = var.vm_size #renamed from vm_size
   network_interface_ids            = [azurerm_network_interface.NIC.id]
-  primary_network_interface_id     = azurerm_network_interface.NIC.id
+  #primary_network_interface_id    = removed, now just the first NIC above
   availability_set_id              = var.availability_set_id
-  delete_data_disks_on_termination = "true"
-  delete_os_disk_on_termination    = "true"
+  #delete_data_disks_on_termination = "true" #removed as there is no way to add data disks directly
+  #delete_os_disk_on_termination    = "true" #moved to provider settings - defaults to true
   license_type                     = var.license_type == null ? null : var.license_type
-  os_profile {
-    computer_name  = var.name
-    admin_username = var.admin_username
-    admin_password = var.admin_password
-    custom_data    = var.custom_data
-  }
-  storage_image_reference {
+  computer_name                    = var.name #moved out of os_profile
+  admin_username                   = var.admin_username #moved out of os_profile
+  admin_password                   = var.admin_password #moved out of os_profile
+  custom_data                      = var.custom_data #moved out of os_profile
+  provision_vm_agent               = true #move out of os_profile_windows_config
+
+  source_image_reference {
     publisher = var.storage_image_reference.publisher
     offer     = var.storage_image_reference.offer
     sku       = var.storage_image_reference.sku
@@ -109,34 +109,25 @@ resource azurerm_virtual_machine VM {
       publisher = local.plan[0].publisher
     }
   }
-  os_profile_windows_config {
-    provision_vm_agent = true
-  }
-  storage_os_disk {
+
+  #storage_os_disk is changed to os_disk but some options are different
+  #this resource is now always a managed disk
+  os_disk {
     name              = "${var.name}-osdisk1"
-    caching           = var.storage_os_disk.caching
-    create_option     = var.storage_os_disk.create_option
-    os_type           = var.storage_os_disk.os_type
-    disk_size_gb      = var.storage_os_disk.disk_size_gb
-    managed_disk_type = var.os_managed_disk_type
+    caching           = var.os_disk.caching
+    storage_account_type = var.os_disk.storage_account_type #var should be renamed
+    disk_size_gb      = var.os_disk.disk_size_gb
   }
-  # This is where the magic to dynamically create storage disk operate
-  dynamic "storage_data_disk" {
-    for_each = var.data_disk_sizes_gb
-    content {
-      name              = "${var.name}-datadisk${storage_data_disk.key + 1}"
-      create_option     = "Empty"
-      lun               = storage_data_disk.key
-      disk_size_gb      = storage_data_disk.value
-      caching           = "ReadWrite"
-      managed_disk_type = var.data_managed_disk_type
-    }
-  }
+  /*storage_os_disk #did not find a replace settings for these {
+    create_option     = var.storage_os_disk.create_option #removed, possible braking change
+    os_type           = var.storage_os_disk.os_type #removed, redundent
+  }*/
+
   dynamic "boot_diagnostics" {
     for_each = local.boot_diagnostic
     content {
-      enabled     = true
-      storage_uri = azurerm_storage_account.boot_diagnostic[0].primary_blob_endpoint
+      #enabled     = true #removed
+      storage_account_uri = azurerm_storage_account.boot_diagnostic[0].primary_blob_endpoint
     }
   }
   dynamic "identity" {
@@ -146,4 +137,28 @@ resource azurerm_virtual_machine VM {
     }
   }
   tags = var.tags
+}
+
+# This is where the magic to dynamically create storage disk operate
+# *** completly changes with windows_virtual_machine:
+# *** is now in 2 seperate resources ***
+
+resource azurerm_managed_disk DataDisk {
+  count                 = length(var.data_disk_sizes_gb)
+
+  name                  = "${var.name}-datadisk${count.index + 1}"
+  location              = var.location
+  resource_group_name   = var.resource_group_name
+  storage_account_type  = var.data_managed_disk_type
+  disk_size_gb          = var.data_disk_sizes_gb[count.index]
+  create_option         = "Empty"
+}
+
+resource azurerm_virtual_machine_data_disk_attachment attached_data_disk {
+  count               = length(var.data_disk_sizes_gb)
+
+  managed_disk_id     = azurerm_managed_disk.DataDisk[count.index].id
+  virtual_machine_id  = azurerm_windows_virtual_machine.VM.id
+  lun                 = count.index + 1 
+  caching             = "ReadWrite"
 }

--- a/option-10-customScriptExtension.tf
+++ b/option-10-customScriptExtension.tf
@@ -14,7 +14,7 @@ resource "azurerm_virtual_machine_extension" "CustomScriptExtension" {
 
   count                = var.custom_data == null ? 0 : 1
   name                 = "CustomScriptExtension"
-  virtual_machine_id   = azurerm_virtual_machine.VM.id
+  virtual_machine_id   = azurerm_windows_virtual_machine.VM.id
   publisher            = "Microsoft.Compute"
   type                 = "CustomScriptExtension"
   type_handler_version = "1.9"

--- a/option-20-AADLoginForWindows.tf
+++ b/option-20-AADLoginForWindows.tf
@@ -7,7 +7,7 @@ variable "AADLoginForWindows" {
 resource "azurerm_virtual_machine_extension" "AADLoginForWindows" {
   count                      = var.AADLoginForWindows == null ? 0 : 1
   name                       = "AADLoginForWindows"
-  virtual_machine_id         = azurerm_virtual_machine.VM.id
+  virtual_machine_id         = azurerm_windows_virtual_machine.VM.id
   publisher                  = "Microsoft.Azure.ActiveDirectory"
   type                       = "AADLoginForWindows"
   type_handler_version       = "0.3"

--- a/option-20-domainJoin.tf
+++ b/option-20-domainJoin.tf
@@ -20,7 +20,7 @@ resource "azurerm_virtual_machine_extension" "DomainJoinExtension" {
   count                = var.domainToJoin == null ? 0 : 1
   name                 = "DomainJoinExtension"
   depends_on           = [azurerm_virtual_machine_extension.CustomScriptExtension]
-  virtual_machine_id   = azurerm_virtual_machine.VM.id
+  virtual_machine_id   = azurerm_windows_virtual_machine.VM.id
   publisher            = "Microsoft.Compute"
   type                 = "JsonADDomainExtension"
   type_handler_version = "1.3"

--- a/option-30-DAAgent.tf
+++ b/option-30-DAAgent.tf
@@ -7,7 +7,7 @@ variable "dependancyAgent" {
 resource "azurerm_virtual_machine_extension" "DAAgentForWindows" {
   count                      = var.dependancyAgent == null ? 0 : 1
   name                       = "DAAgentForWindows"
-  virtual_machine_id         = azurerm_virtual_machine.VM.id
+  virtual_machine_id         = azurerm_windows_virtual_machine.VM.id
   publisher                  = "Microsoft.Azure.Monitoring.DependencyAgent"
   type                       = "DependencyAgentWindows"
   type_handler_version       = "9.5"

--- a/option-40-MicrosoftMonitoringAgent.tf
+++ b/option-40-MicrosoftMonitoringAgent.tf
@@ -18,7 +18,7 @@ resource "azurerm_virtual_machine_extension" "MicrosoftMonitoringAgent" {
   count                      = var.monitoringAgent == null ? 0 : 1
   name                       = "MicrosoftMonitoringAgent"
   depends_on                 = [azurerm_virtual_machine_extension.DAAgentForWindows]
-  virtual_machine_id         = azurerm_virtual_machine.VM.id
+  virtual_machine_id         = azurerm_windows_virtual_machine.VM.id
   publisher                  = "Microsoft.EnterpriseCloud.Monitoring"
   type                       = "MicrosoftMonitoringAgent"
   type_handler_version       = "1.0"

--- a/option-50-antiMalware.tf
+++ b/option-50-antiMalware.tf
@@ -23,7 +23,7 @@ resource "azurerm_virtual_machine_extension" "IaaSAntimalware" {
   count                      = var.antimalware == null ? 0 : 1
   name                       = "IaaSAntimalware"
   depends_on                 = [azurerm_virtual_machine_extension.MicrosoftMonitoringAgent]
-  virtual_machine_id         = azurerm_virtual_machine.VM.id
+  virtual_machine_id         = azurerm_windows_virtual_machine.VM.id
   publisher                  = "Microsoft.Azure.Security"
   type                       = "IaaSAntimalware"
   type_handler_version       = "1.5"

--- a/option-60-shutdownConfig.tf
+++ b/option-60-shutdownConfig.tf
@@ -72,7 +72,7 @@ DEPLOY
 
   # these key-value pairs are passed into the ARM Template's `parameters` block
   parameters = {
-    "computerName" = azurerm_virtual_machine.VM.name
+    "computerName" = azurerm_windows_virtual_machine.VM.name
     "autoShutdownStatus" = var.shutdownConfig.autoShutdownStatus
     "autoShutdownTime" = var.shutdownConfig.autoShutdownTime
     "autoShutdownTimeZone" = var.shutdownConfig.autoShutdownTimeZone

--- a/option-70-encryptDisks.tf
+++ b/option-70-encryptDisks.tf
@@ -18,7 +18,7 @@ resource "azurerm_virtual_machine_extension" "AzureDiskEncryption" {
   count                      = var.encryptDisks == null ? 0 : 1
   name                       = "AzureDiskEncryption"
   depends_on                 = [azurerm_template_deployment.autoshutdown]
-  virtual_machine_id         = azurerm_virtual_machine.VM.id
+  virtual_machine_id         = azurerm_windows_virtual_machine.VM.id
   publisher                  = "Microsoft.Azure.Security"
   type                       = "AzureDiskEncryption"
   type_handler_version       = "2.2"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "vm" {
-  value = azurerm_virtual_machine.VM
+  value = azurerm_windows_virtual_machine.VM
 }
 
 output "Nic0" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,8 @@ variable "name" {
 }
 
 variable "data_disk_sizes_gb" {
-  description = "List of data disk sizes in gigabytes required for the VM. EG.: If 3 data disks are required then data_disk_size_gb might look like [40,100,60] for disk 1 of 40 GB, disk 2 of 100 GB and disk 3 of 60 GB"
+  type        = list
+  description = "Map of data disk sizes in gigabytes required for the VM. EG.: If 3 data disks are required then data_disk_size_gb might look like [40,100,60] for disk 1 of 40 GB, disk 2 of 100 GB and disk 3 of 60 GB"
   default     = []
 }
 
@@ -103,10 +104,6 @@ variable "admin_password" {
   description = "Name of the VM admin account"
 }
 
-variable "os_managed_disk_type" {
-  default = "Standard_LRS"
-}
-
 variable "data_managed_disk_type" {
   default = "Standard_LRS"
 }
@@ -129,12 +126,14 @@ variable "plan" {
   default     = null
 }
 
-variable "storage_os_disk" {
+variable "os_disk" {
+  #was storage_os_disk
   default = {
     caching       = "ReadWrite"
-    create_option = "FromImage"
-    os_type       = null
-    disk_size_gb  = null
+    #create_option = "FromImage" #removed
+    #os_type       = null #removed
+    disk_size_gb  = null      
+    storage_account_type = "Standard_LRS" #was os_managed_disk_type, a sperate variable
   }
 }
 
@@ -145,7 +144,7 @@ variable "license_type" {
 
 variable "availability_set_id" {
   description = "Sets the id for the availability set to use for the VM"
-  default = ""
+  default = null #was ""
 }
 
 variable "boot_diagnostic" {


### PR DESCRIPTION
As per issue #2, here is the pull request to migrate to windows_virtual_machine resource. This will be required for future maintenance as the virtual_machine resource is feature frozen. 

No major breaking changes but a couple of variable changes are needed:
- os_disk is the biggest change. I had to remove create_option adn os_type as they are no longer needed. I also moved os_ manged_disk_type into os_disk and renamed to storage_account_type

- The default value of availability_set_id was changed to null to comply with the resource's requirements (was a zero-length string)

Since it's a new resource, great care must be exercised when upgrading to this as the old VMs *will* be destroyed.

I have left comments in the file to explain the changes, but can removed them to clean up the files.
